### PR TITLE
Get products by min price

### DIFF
--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -168,6 +168,7 @@ class ProductView(ViewSet):
         direction = request.query_params.get('direction', None)
         name = request.query_params.get('name', None)
         location = request.query_params.get('location', None)
+        min_price = request.query_params.get('min_price', None)
 
 
         if number_sold:
@@ -187,6 +188,9 @@ class ProductView(ViewSet):
 
         if location is not None:
             products = products.filter(location__contains=location)
+
+        if min_price is not None:
+            products = products.filter(price__gte=min_price)
 
         serializer = ProductSerializer(products, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
Added query_param check for "min_price" that results in a products list filtered with only those with a price greater than or equal to the value of min_price.

Fixes #7 